### PR TITLE
DUGK-65 Removed husky for git-hooks

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 if git diff --cached --name-only | grep "^client/" >/dev/null; then
     cd client

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 if git diff --cached --name-only | grep "^client/" >/dev/null; then
-    cd client
+    cd client || exit
     yarn install
     yarn format && yarn syntax
 else

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -5,5 +5,5 @@ if git diff --cached --name-only | grep "^client/" >/dev/null; then
     yarn install
     yarn format && yarn syntax
 else
-    echo "No changes in the client directory. Skipping pre-commit hook."
+    printf "No changes in the client directory. Skipping pre-commit hook."
 fi

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -2,8 +2,8 @@
 
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
-if git diff --name-only origin/$BRANCH_NAME...HEAD | grep "^client/" >/dev/null; then
-    cd client
+if git diff --name-only origin/"$BRANCH_NAME"...HEAD | grep "^client/" >/dev/null; then
+    cd client || exit
     yarn install
     yarn jest . --coverage=false
 else

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 if git diff --name-only origin...HEAD | grep "^client/" >/dev/null; then
     cd client

--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 
-if git diff --name-only origin...HEAD | grep "^client/" >/dev/null; then
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+if git diff --name-only origin/$BRANCH_NAME...HEAD | grep "^client/" >/dev/null; then
     cd client
     yarn install
     yarn jest . --coverage=false

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Before you make commits, please install the git hooks provided in the repository
 script/configure-git-hooks.sh
 ```
 
-This will ensure that your commits are formatted correctly and that the tests pass before you push your changes.
+This will ensure that your commits are formatted correctly and that the unittests pass before you push your changes. Be aware that the tests take a long time to run. If you want to skip the tests or formatting, you can use the `--no-verify` flag on `git commit` or `git push`.
 
 ### Infrastructure Components
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,22 @@ The best way to use the DTaaS software is via a vagrant virtual machine. The ins
 The rest of the information on this page is aimed at current and potential contributors to DTaaS software development.
 
 To install the development environment, run
+
 ```bash
 bash script/install.bash
 ```
 
+Before you make commits, please install the git hooks provided in the repository.
+
+```shell
+script/configure-git-hooks.sh
+```
+
+This will ensure that your commits are formatted correctly and that the tests pass before you push your changes.
+
 ### Infrastructure Components
 
 The application uses [Træfik](https://github.com/traefik/traefik) and [ML Workspace](https://github.com/ml-tooling/ml-workspace) open-source components. It is possible to run [jupyterlab notebooks](script/jupyter.sh), [Grafana servers](script/grafana.sh) and [InfluxDB](script/influx.sh) as part of the DTaaS software. But terminal-based Jupyterlab, Grafana and InfluxDB are not installed in the default setup.
-
 
 ## License
 

--- a/client/README.md
+++ b/client/README.md
@@ -8,7 +8,7 @@ The following steps are required to setup the environment and build the applicat
 
 ### Prerequisites
 
-If you are using yarn 2, please change the package.json to use `postinstall` instead `prepare` scripts. This application is using **Husky** for pre-commit hooks, read more about husky and yarn 2 [here](https://typicode.github.io/husky/#/?id=yarn-2).
+If you are using yarn 2, please change the package.json to use `postinstall` instead `prepare` scripts.
 
 ```bash
 cd client

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "start": "script/start.bash",
     "clean": "script/clean.bash",
     "format": "prettier --ignore-path ../.gitignore --write \"**/*.{ts,tsx,css,scss}\"",
-    "prepare": "echo prepareing"
+    "prepare": "../script/configure-git-hooks.sh"
   },
   "eslintConfig": {
     "extends": [

--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
     "start": "script/start.bash",
     "clean": "script/clean.bash",
     "format": "prettier --ignore-path ../.gitignore --write \"**/*.{ts,tsx,css,scss}\"",
-    "prepare": "cd .. && husky install"
+    "prepare": "echo prepareing"
   },
   "eslintConfig": {
     "extends": [
@@ -71,7 +71,6 @@
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.30.1",
-    "husky": "^8.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "playwright": "^1.32.1",

--- a/client/src/components/tab/TabComponent.tsx
+++ b/client/src/components/tab/TabComponent.tsx
@@ -3,12 +3,10 @@ import { Paper } from '@mui/material';
 import TabRender from './subcomponents/TabRender';
 import { Tab, TabList, TabPanel, Tabs } from './subcomponents/TabStyles';
 
-
 export interface TabData {
   label: string;
   body: JSX.Element;
 }
-
 
 function TabComponent(props: { tabs: TabData[] }) {
   return (
@@ -22,11 +20,11 @@ function TabComponent(props: { tabs: TabData[] }) {
     >
       <Tabs>
         <TabList>
-          {props.tabs.map((tab,index) => (
+          {props.tabs.map((tab, index) => (
             <Tab key={index}>{tab.label}</Tab>
           ))}
         </TabList>
-        {props.tabs.map((tab,index) => (
+        {props.tabs.map((tab, index) => (
           <TabPanel key={index}>
             <TabRender index={index}>{tab}</TabRender>
           </TabPanel>

--- a/client/src/components/tab/subcomponents/TabRender.tsx
+++ b/client/src/components/tab/subcomponents/TabRender.tsx
@@ -8,7 +8,7 @@ interface TabRenderProps {
 }
 
 function TabRender(props: TabRenderProps) {
-  const { children: tab,index } = props;
+  const { children: tab, index } = props;
 
   return (
     <Box
@@ -23,8 +23,7 @@ function TabRender(props: TabRenderProps) {
         flexGrow: 1,
       }}
     >
-
-        {tab.body}
+      {tab.body}
     </Box>
   );
 }

--- a/client/src/route/digitaltwins/Workflows.tsx
+++ b/client/src/route/digitaltwins/Workflows.tsx
@@ -1,30 +1,25 @@
 import * as React from 'react';
 import Iframe from 'components/Iframe';
-import TabComponent, {
-  TabData,
-} from 'components/tab/TabComponent';
+import TabComponent, { TabData } from 'components/tab/TabComponent';
 import tabs from './WorkflowsData';
 
 const jupyterURL = window.env.REACT_APP_URL_DT;
 
-const tabData: TabData[] = 
-  tabs.map((tab, i) => ({
-    label: tab.label,
-    body: (
-      <>
-        {tab.body}
-        {i === 0 && (
-          <Iframe
-            title={`JupyterLight-Demo-${tab.label}`}
-            url={jupyterURL}
-            fullsize
-          />
-        )}
-      </>
-    ),
-  }))
-;
-
+const tabData: TabData[] = tabs.map((tab, i) => ({
+  label: tab.label,
+  body: (
+    <>
+      {tab.body}
+      {i === 0 && (
+        <Iframe
+          title={`JupyterLight-Demo-${tab.label}`}
+          url={jupyterURL}
+          fullsize
+        />
+      )}
+    </>
+  ),
+}));
 function Workflows() {
   return <TabComponent tabs={tabData} />;
 }

--- a/client/src/route/library/Components.tsx
+++ b/client/src/route/library/Components.tsx
@@ -2,28 +2,25 @@
 src: https://mui.com/material-ui/react-tabs/
 */
 import * as React from 'react';
-import TabComponent, {
-  TabData,
-} from 'components/tab/TabComponent';
+import TabComponent, { TabData } from 'components/tab/TabComponent';
 import Iframe from 'components/Iframe';
 import tabs from './ComponentsData';
 
 const jupyterURL = window.env.REACT_APP_URL_LIB;
 
-const tabsData: TabData[] = 
-  tabs.map((tab) => ({
-    label: tab.label,
-    body: (
-      <>
-        {tab.body}
-        <Iframe
-          title={`JupyterLight-Demo-${tab.label}`}
-          url={`${jupyterURL}`}
-          fullsize
-        />
-      </>
-    ),
-  }));
+const tabsData: TabData[] = tabs.map((tab) => ({
+  label: tab.label,
+  body: (
+    <>
+      {tab.body}
+      <Iframe
+        title={`JupyterLight-Demo-${tab.label}`}
+        url={`${jupyterURL}`}
+        fullsize
+      />
+    </>
+  ),
+}));
 
 function LibComponents() {
   return <TabComponent tabs={tabsData} />;

--- a/client/test/unitTests/Components/TabComponent.test.tsx
+++ b/client/test/unitTests/Components/TabComponent.test.tsx
@@ -4,12 +4,10 @@ import userEvent from '@testing-library/user-event';
 import TabComponent, { TabData } from 'components/tab/TabComponent';
 
 describe('TabComponent', () => {
-  test('empty tab renders',  () => {
-    const tabs: TabData[] = [
-    ];
+  test('empty tab renders', () => {
+    const tabs: TabData[] = [];
     render(<TabComponent tabs={tabs} />);
     expect(true);
-
   });
 
   test('renders tabs with labels and default tab open', () => {
@@ -41,6 +39,4 @@ describe('TabComponent', () => {
     expect(getByText('Tab 2 content')).toBeInTheDocument();
     expect(queryByText('Tab 3 content')).not.toBeInTheDocument();
   });
-
-
 });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5857,11 +5857,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-husky@^8.0.0:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"

--- a/script/configure-git-hooks.sh
+++ b/script/configure-git-hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+git config --local core.hooksPath .git-hooks
+printf "Git hooks configured successfully. See .git-hooks for more information."


### PR DESCRIPTION
Husky was essentially an [npm wrapper for core.hooksPath](https://dev.to/azu/git-hooks-without-extra-dependencies-like-husky-in-node-js-project-jjp) with extra functionality that we don't use.

The hooks can be configured in 3 ways.
- Running `script/configure-git-hooks.sh`
- Running `yarn install` from the client directory
- Running `git config --local core.hooksPath .git-hooks` manually

PR also contains formatting from a previous PR that was missed because of failing hooks.