### PR TITLE
Changed naming of function which made no sense

### DIFF
--- a/client/src/components/AssetBoard/AssetCard.tsx
+++ b/client/src/components/AssetBoard/AssetCard.tsx
@@ -29,7 +29,7 @@ const Description = styled(Typography)`
   text-overflow: ellipsis;
 `;
 
-function CardActionAreaContainer(asset: Asset) {
+function CardMainContainer(asset: Asset) {
   return (
     <Grid container>
       <Grid item xs={7}>
@@ -82,7 +82,7 @@ function AssetCard(props: CardProps) {
       }}
     >
       <Header variant="h6">{data.name}</Header>
-      <CardActionAreaContainer {...data} />
+      <CardMainContainer {...data} />
       <CardButtonsContainer {...data} />
     </Card>
   );

--- a/client/src/components/AssetBoard/AssetCard.tsx
+++ b/client/src/components/AssetBoard/AssetCard.tsx
@@ -29,7 +29,7 @@ const Description = styled(Typography)`
   text-overflow: ellipsis;
 `;
 
-function CardMainContainer(asset: Asset) {
+function CardDisplayArea(asset: Asset) {
   return (
     <Grid container>
       <Grid item xs={7}>
@@ -82,7 +82,7 @@ function AssetCard(props: CardProps) {
       }}
     >
       <Header variant="h6">{data.name}</Header>
-      <CardMainContainer {...data} />
+      <CardDisplayArea {...data} />
       <CardButtonsContainer {...data} />
     </Card>
   );


### PR DESCRIPTION
The previous name indicated that you were able to click on the card "action area", but since we deleted that functionality, I thought that the naming should be different.

Name could also be something different? E.g. "CardInputContainer"